### PR TITLE
Fix editing an admin by another admin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,6 +78,7 @@ class UsersController < ApplicationController
 
   def set_user!
     @user = user_to_edit
+    @user.editing_user = current_user
   end
 
   def set_and_redirect_if_cannot_edit_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,11 @@ class User < ApplicationRecord
 
   scope :with_active_subscription, -> { joins(:subscriptions).where("subscriptions.created_at > ?", 1.year.ago) }
 
+  attr_accessor :editing_user
+
   validate :cannot_demote_themselves
   def cannot_demote_themselves
-    if admin_was == true && admin == false
+    if editing_user == self && admin_was == true && admin == false
       errors.add(:admin, "no puedes eliminar tu propia condición de administrador, debes pedirle a otro administrador que lo haga.")
     end
   end


### PR DESCRIPTION
Fixes #45.

The patch in speedcubingfrance/speedcubingfrance.org#82 didn't apply as both repos history have diverged, so I'm mirroring the PR here.