### PR TITLE
Check before calling downcase

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,7 @@ module ApplicationHelper
   # https://github.com/thewca/worldcubeassociation.org/blob/c05b272fc0c8cef14d465df12c7b6c6a0da3779f/WcaOnRails/app/helpers/application_helper.rb#L202
   def flag_icon(iso2, html_options = {})
     html_options[:class] ||= ""
-    html_options[:class] += " flag-icon flag-icon-#{iso2.downcase}"
+    html_options[:class] += " flag-icon flag-icon-#{iso2&.downcase}"
     content_tag :span, "", html_options
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ApplicationRecord
   end
 
   def country_name
-    Country.find_by_iso2(country_iso2).name
+    Country.find_by_iso2(country_iso2)&.name
   end
 
   def friendly_delegate_status


### PR DESCRIPTION
Fixes an issue reported by @Ivan-Brigidano.
Pretty sure the issue is linked to the states json being outdated.
The error occurs because we call downcase on a "nil" string (which means the user's country is not found).
So after merging this going to the users list should display correctly, with one (or more) users having no country flag ; could you please tell me who they are so that I could figure out what happened?
